### PR TITLE
Add API endpoint for Login and Registration

### DIFF
--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -1,6 +1,7 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import Providers from "next-auth/providers";
 import NextAuth, { InitOptions } from "next-auth";
+import { getUserByCredentials } from "server/mysql/actions/user";
 
 const options: InitOptions = {
   providers: [
@@ -15,9 +16,8 @@ const options: InitOptions = {
         password: { label: "Password", type: "password" },
       },
       async authorize(credentials) {
-        const { email } = credentials;
-        // TODO - Add logic to retrieve user based on credentials
-        const user = { id: 1, name: "Signed Test User", email: email };
+        const { email, password } = credentials;
+        const user = await getUserByCredentials(email, password);
 
         if (user) {
           return user;

--- a/pages/api/auth/register.ts
+++ b/pages/api/auth/register.ts
@@ -1,0 +1,45 @@
+import type { NextApiHandler, NextApiRequest, NextApiResponse } from "next";
+import { isValidEmail, isValidPassword } from "server/auth";
+import { registerUser } from "server/mysql/actions/user";
+
+const handler: NextApiHandler = async (
+  req: NextApiRequest,
+  res: NextApiResponse
+) => {
+  const { method, body } = req;
+  switch (method) {
+    case "POST":
+      try {
+        const { name, email, password } = body;
+        validateRegistrationData(name, email, password);
+        await registerUser(name, email, password);
+
+        res.status(200).json({ success: true });
+      } catch (e) {
+        res.status(500).json({ message: e.message });
+      }
+      break;
+    default:
+      res.setHeader("Allow", ["POST"]);
+      res.status(405).end(`Method ${method} Not Allowed`);
+  }
+};
+
+function validateRegistrationData(
+  name: string,
+  email: string,
+  password: string
+): void {
+  if (!name || name.trim().length == 0) {
+    throw Error("Please enter a valid name");
+  }
+
+  if (!email || !isValidEmail(email)) {
+    throw Error("Please enter a valid email");
+  }
+
+  if (!password || !isValidPassword(password)) {
+    throw Error("Invalid password. Please check the password requirements");
+  }
+}
+export default handler;

--- a/pages/home.tsx
+++ b/pages/home.tsx
@@ -1,6 +1,9 @@
 import Head from "next/head";
 import PrivateLayout from "components/layouts/private-layout";
 import { getSession } from "next-auth/client";
+import React from "react";
+import Link from "next/link";
+import { Button } from "react-bootstrap";
 
 interface HomeProps {
   session: {
@@ -21,8 +24,21 @@ export function Home(props: HomeProps): JSX.Element {
         <title>Home | TipTracker</title>
       </Head>
 
-      <h1>Home</h1>
-      <h2>Welcome back: {session?.user?.name || "Guest"}</h2>
+      {session ? (
+        <>
+          <h1>Home</h1>
+          <h2>Welcome back: {session?.user?.name.split(" ")[0] || "Guest"}</h2>
+        </>
+      ) : (
+        <>
+          <h1>Hello Guest</h1>
+          <Link href="/api/auth/signin">
+            <Button size="lg" variant="warning" className="mt-4">
+              Login
+            </Button>
+          </Link>
+        </>
+      )}
     </PrivateLayout>
   );
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -28,7 +28,7 @@ const Home: React.FunctionComponent = () => {
             <h1 className={styles.focusText}>
               Tip<span style={{ color: "black" }}>Tracker</span>
             </h1>
-            <Link href="/calendar">
+            <Link href="/home">
               <Button size="lg" variant="warning" className="mt-4">
                 Continue
               </Button>

--- a/server/auth/index.ts
+++ b/server/auth/index.ts
@@ -1,14 +1,35 @@
 import bcrypt from "bcrypt";
 
-export async function isValidPassword(
-  password,
-  passwordHash
+export async function matchesPasswordHash(
+  password: string,
+  passwordHash: string
 ): Promise<boolean> {
   return await bcrypt.compare(password, passwordHash);
 }
 
-export async function getPasswordHash(password): Promise<string> {
-  const salt = await bcrypt.genSaltSync(process.env.BYCRYPT_SALT_ROUNDS);
+export async function getPasswordHash(password: string): Promise<string> {
+  const saltRounds = Number(process.env.BYCRYPT_SALT_ROUNDS);
+  const salt = await bcrypt.genSaltSync(saltRounds);
   const passwordHash = await bcrypt.hashSync(password, salt);
   return passwordHash;
+}
+
+/**
+ * Check if the new registering user's password is valid.
+ * Currently it only checks if the length >= 8
+ *
+ * @param password New password entered by the user
+ */
+export function isValidPassword(password: string): boolean {
+  return password.trim().length >= 8;
+}
+
+/**
+ * Uses regular expression to check if the email is valid
+ *
+ * @param email Email provided by the user
+ */
+export function isValidEmail(email: string): boolean {
+  const re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+  return re.test(String(email).toLowerCase());
 }

--- a/server/mysql/actions/user.ts
+++ b/server/mysql/actions/user.ts
@@ -1,17 +1,49 @@
-import { isValidPassword } from "server/auth";
+import { getPasswordHash, matchesPasswordHash } from "server/auth";
 import { query } from "../index";
 
-export async function getUserByCredentials(credentials) {
-  const { email, password } = credentials;
-
+export async function getUserByCredentials(email: string, password: string) {
   const user = await query("SELECT * FROM users WHERE email = ?", [email]);
 
   if (user.length == 1) {
     const currentUser = user[0];
-    if (await isValidPassword(password, currentUser["password_hash"])) {
-      return user;
+    if (await matchesPasswordHash(password, currentUser["password_hash"])) {
+      return currentUser;
     }
   }
 
   return null;
+}
+
+/**
+ * Make sure to validate the user data before calling this method
+ *
+ * @param name Valid name for the new user
+ * @param email Email address for the user
+ * @param password Password for the user
+ */
+export async function registerUser(
+  name: string,
+  email: string,
+  password: string
+) {
+  if (await isExistingEmail(email)) {
+    throw Error(`${email} is already an registered account`);
+  }
+
+  try {
+    const passwordHash = await getPasswordHash(password.trim());
+
+    await query(
+      "INSERT INTO users (name, email, password_hash) values (?, ?, ?)",
+      [name, email, passwordHash]
+    );
+  } catch (err) {
+    throw Error(`Internal server error. Please try again later`);
+  }
+}
+
+export async function isExistingEmail(email: string): Promise<boolean> {
+  const count = await query("SELECT 1 FROM users WHERE email = ?", [email]);
+
+  return count.length >= 1;
 }


### PR DESCRIPTION
## Changes
- Added new route `/api/auth/register` to handle user registration
- Added backend validation for user registration:
  - Email is valid (using regex) and unique
  - Password is of length at least 8 characters (we can add more complexity or requirements for future goal since strong authentication is not the biggest priority right now)
- Used `bcrypt` to generate salt and hash new user password
- Added login flow
  - Use `signin('credentials', {email: 'test@tiptracker.com', password: 'password})` method in custom login screens if needed.
- Added same session example for Home screen.

## Testing
1. Re-run the database script to make sure the schemas are set properly.
2. Send a post request to `/api/auth/register` to create a new user with the following body:
```
{
  "name" : "Name for new user",
  "email": "Email for new user",
  "password": "Password for new user"
}
```
3. Login with the new user. The home page should display the new user's name.
4. Repeat step 2 with invalid password (length < 8) or duplicate/invalid email. Check database to ensure the new user isn't created.
5. Repeat step 3 with invalid credentials. Ensure login is not allowed (Make sure to visit `/api/auth/signout` if previously logged in. This will delete the cookies for the user)