### PR TITLE
Add Data Visualization on User Dashboard

### DIFF
--- a/components/analytics/trends-container/trendsLine.tsx
+++ b/components/analytics/trends-container/trendsLine.tsx
@@ -28,7 +28,7 @@ const TrendsLine = ({ value, color, item }: TrendsLineProps) => (
         {KEY_ICONS[item].icon}
       </OverlayTrigger>
     </Col>
-    <Col xs={9} style={{ color }}>
+    <Col xs={10} style={{ color }}>
       {value}
     </Col>
   </Row>

--- a/components/visualizations/loader.tsx
+++ b/components/visualizations/loader.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import Spinner from "react-bootstrap/Spinner";
+
+const Loader = () => (
+  <Spinner animation="border" role="status" className="align-self-center">
+    <span className="sr-only">Loading...</span>
+  </Spinner>
+);
+
+export default Loader;

--- a/components/visualizations/monthly-summary/styles.module.css
+++ b/components/visualizations/monthly-summary/styles.module.css
@@ -1,0 +1,13 @@
+.container {
+  width: 100%;
+  height: 100%;
+  box-shadow: 0px 10px 30px rgba(172, 172, 172, 0.6);
+  background-color: #fff;
+  border-radius: 10px;
+  padding: 2rem;
+  display: flex;
+  justify-content: center;
+  min-height: 550px;
+  min-width: 300px;
+  margin: auto;
+}

--- a/components/visualizations/monthly-summary/wagesDistribution.tsx
+++ b/components/visualizations/monthly-summary/wagesDistribution.tsx
@@ -35,7 +35,7 @@ const WagesDistribution = (): JSX.Element => {
           <ResponsivePie
             data={earningsData}
             valueFormat={(v) => `$ ${v}`}
-            margin={{ top: 40, right: 80, bottom: 80, left: 80 }}
+            margin={{ top: 40, right: 80, bottom: 80, left: 100 }}
             innerRadius={0.5}
             padAngle={0.7}
             cornerRadius={3}

--- a/components/visualizations/monthly-summary/wagesDistribution.tsx
+++ b/components/visualizations/monthly-summary/wagesDistribution.tsx
@@ -1,0 +1,116 @@
+import { ResponsivePie } from "@nivo/pie";
+import { format } from "date-fns";
+import React, { useEffect, useState } from "react";
+import Loader from "../loader";
+
+import styles from "./styles.module.css";
+
+const data = [
+  {
+    id: "wages",
+    label: "Wages",
+    value: 537,
+  },
+  {
+    id: "cashTips",
+    label: "Cash Tips",
+    value: 354,
+  },
+  {
+    id: "ccTips",
+    label: "Credit Card Tips",
+    value: 467,
+  },
+];
+
+const WagesDistribution = (): JSX.Element => {
+  const [loading, setLoading] = useState(false);
+  const [earningsData, setEarningsData] = useState([]);
+
+  const currentDate = new Date();
+
+  useEffect(() => {
+    setLoading(true);
+    setTimeout(function () {
+      setEarningsData(data);
+      setLoading(false);
+    }, 1000);
+  }, []);
+
+  return (
+    <div className={styles.container}>
+      {loading ? (
+        <Loader />
+      ) : (
+        <div style={{ height: 400, width: "100%" }} className="text-center">
+          <h5>Earnings Distribution for</h5>
+          <h3>past 30 days</h3>
+          <ResponsivePie
+            data={earningsData}
+            valueFormat={(v) => `$ ${v}`}
+            margin={{ top: 40, right: 80, bottom: 80, left: 80 }}
+            innerRadius={0.5}
+            padAngle={0.7}
+            cornerRadius={3}
+            colors={{ scheme: "nivo" }}
+            borderWidth={1}
+            borderColor={{ from: "color", modifiers: [["darker", 0.2]] }}
+            radialLabelsSkipAngle={10}
+            radialLabelsTextColor="#333333"
+            radialLabelsLinkColor={{ from: "color" }}
+            radialLabel={(d) => d.label}
+            sliceLabelsSkipAngle={10}
+            sliceLabelsTextColor="#333333"
+            defs={[
+              {
+                id: "dots",
+                type: "patternDots",
+                background: "inherit",
+                color: "rgba(255, 255, 255, 0.3)",
+                size: 4,
+                padding: 1,
+                stagger: true,
+              },
+              {
+                id: "lines",
+                type: "patternLines",
+                background: "inherit",
+                color: "rgba(255, 255, 255, 0.3)",
+                rotation: -45,
+                lineWidth: 6,
+                spacing: 10,
+              },
+            ]}
+            legends={[
+              {
+                anchor: "bottom",
+                direction: "row",
+                justify: false,
+                translateX: 0,
+                translateY: 56,
+                itemsSpacing: 0,
+                itemWidth: 100,
+                itemHeight: 18,
+                itemTextColor: "#999",
+                itemDirection: "left-to-right",
+                itemOpacity: 1,
+                symbolSize: 18,
+                symbolShape: "circle",
+                effects: [
+                  {
+                    on: "hover",
+                    style: {
+                      itemTextColor: "#000",
+                    },
+                  },
+                ],
+              },
+            ]}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default WagesDistribution;

--- a/components/visualizations/monthly-summary/wagesDistribution.tsx
+++ b/components/visualizations/monthly-summary/wagesDistribution.tsx
@@ -1,37 +1,27 @@
 import { ResponsivePie } from "@nivo/pie";
 import React, { useEffect, useState } from "react";
+import { getEarningsDistributionData } from "src/actions/visualizations";
 import Loader from "../loader";
 
 import styles from "./styles.module.css";
-
-const data = [
-  {
-    id: "wages",
-    label: "Wages",
-    value: 537,
-  },
-  {
-    id: "cashTips",
-    label: "Cash Tips",
-    value: 354,
-  },
-  {
-    id: "ccTips",
-    label: "Credit Card Tips",
-    value: 467,
-  },
-];
 
 const WagesDistribution = (): JSX.Element => {
   const [loading, setLoading] = useState(false);
   const [earningsData, setEarningsData] = useState([]);
 
+  const days = 30;
+
   useEffect(() => {
     setLoading(true);
-    setTimeout(function () {
-      setEarningsData(data);
-      setLoading(false);
-    }, 1000);
+    getEarningsDistributionData(30)
+      .then((data) => setEarningsData(data))
+      .catch(() => {
+        setEarningsData([]);
+        window.alert(
+          "We could not retrieve the earnings distribution data. Please try again later"
+        );
+      })
+      .finally(() => setLoading(false));
   }, []);
 
   return (
@@ -41,7 +31,7 @@ const WagesDistribution = (): JSX.Element => {
       ) : (
         <div style={{ height: 400, width: "100%" }} className="text-center">
           <h5>Earnings Distribution for</h5>
-          <h3>past 30 days</h3>
+          <h3>past {days} days</h3>
           <ResponsivePie
             data={earningsData}
             valueFormat={(v) => `$ ${v}`}

--- a/components/visualizations/monthly-summary/wagesDistribution.tsx
+++ b/components/visualizations/monthly-summary/wagesDistribution.tsx
@@ -1,5 +1,4 @@
 import { ResponsivePie } from "@nivo/pie";
-import { format } from "date-fns";
 import React, { useEffect, useState } from "react";
 import Loader from "../loader";
 
@@ -26,8 +25,6 @@ const data = [
 const WagesDistribution = (): JSX.Element => {
   const [loading, setLoading] = useState(false);
   const [earningsData, setEarningsData] = useState([]);
-
-  const currentDate = new Date();
 
   useEffect(() => {
     setLoading(true);

--- a/components/visualizations/monthly-summary/wagesTrends.tsx
+++ b/components/visualizations/monthly-summary/wagesTrends.tsx
@@ -1,47 +1,29 @@
 import { ResponsiveLine } from "@nivo/line";
-import { addDays, format } from "date-fns";
 import React, { useEffect, useState } from "react";
+import { getEarningsTrendsData } from "src/actions/visualizations";
 import Loader from "../loader";
 
 import styles from "./styles.module.css";
-
-const getDummyData = () => {
-  const dummyData = [
-    { id: "Wages", data: [] },
-    { id: "Cash Tips", data: [] },
-    { id: "Credit Card Tips", data: [] },
-  ];
-
-  const today = new Date();
-  let currentDate = addDays(today, -15);
-
-  while (currentDate <= today) {
-    const day = format(currentDate, "d");
-
-    for (let i = 0; i < dummyData.length; i++) {
-      dummyData[i].data.push({
-        x: day,
-        y: (Math.random() * 200).toFixed(2),
-      });
-    }
-
-    currentDate = addDays(currentDate, 1);
-  }
-
-  return dummyData;
-};
 
 const WagesTrends = (): JSX.Element => {
   const [loading, setLoading] = useState(false);
   const [earningsData, setEarningsData] = useState([]);
 
+  const days = 15;
+
   useEffect(() => {
     setLoading(true);
-    setTimeout(function () {
-      const data = getDummyData();
-      setEarningsData(data);
-      setLoading(false);
-    }, 500);
+    getEarningsTrendsData(days)
+      .then((data) => {
+        setEarningsData(data);
+      })
+      .catch(() => {
+        setEarningsData([]);
+        window.alert(
+          "We could not retrieve the earnings trends data. Please try again later"
+        );
+      })
+      .finally(() => setLoading(false));
   }, []);
 
   return (
@@ -51,7 +33,7 @@ const WagesTrends = (): JSX.Element => {
       ) : (
         <div style={{ height: 400, width: "100%" }} className="text-center">
           <h5>Earnings Trends for</h5>
-          <h3>past 15 days</h3>
+          <h3>past {days} days</h3>
           <ResponsiveLine
             data={earningsData}
             margin={{ top: 50, right: 15, bottom: 75, left: 50 }}
@@ -65,7 +47,7 @@ const WagesTrends = (): JSX.Element => {
               reverse: false,
             }}
             yFormat=" >-.2f"
-            curve="cardinal"
+            curve="linear"
             lineWidth={1}
             axisTop={null}
             axisRight={null}

--- a/components/visualizations/monthly-summary/wagesTrends.tsx
+++ b/components/visualizations/monthly-summary/wagesTrends.tsx
@@ -43,7 +43,7 @@ const WagesTrends = (): JSX.Element => {
               type: "linear",
               min: "auto",
               max: "auto",
-              stacked: true,
+              stacked: false,
               reverse: false,
             }}
             yFormat=" >-.2f"

--- a/components/visualizations/monthly-summary/wagesTrends.tsx
+++ b/components/visualizations/monthly-summary/wagesTrends.tsx
@@ -1,0 +1,132 @@
+import { ResponsiveLine } from "@nivo/line";
+import { addDays, format } from "date-fns";
+import React, { useEffect, useState } from "react";
+import Loader from "../loader";
+
+import styles from "./styles.module.css";
+
+const getDummyData = () => {
+  const dummyData = [
+    { id: "Wages", data: [] },
+    { id: "Cash Tips", data: [] },
+    { id: "Credit Card Tips", data: [] },
+  ];
+
+  const today = new Date();
+  let currentDate = addDays(today, -15);
+
+  while (currentDate <= today) {
+    const day = format(currentDate, "d");
+
+    for (let i = 0; i < dummyData.length; i++) {
+      dummyData[i].data.push({
+        x: day,
+        y: (Math.random() * 200).toFixed(2),
+      });
+    }
+
+    currentDate = addDays(currentDate, 1);
+  }
+
+  return dummyData;
+};
+
+const WagesTrends = (): JSX.Element => {
+  const [loading, setLoading] = useState(false);
+  const [earningsData, setEarningsData] = useState([]);
+
+  useEffect(() => {
+    setLoading(true);
+    setTimeout(function () {
+      const data = getDummyData();
+      setEarningsData(data);
+      setLoading(false);
+    }, 500);
+  }, []);
+
+  return (
+    <div className={styles.container}>
+      {loading ? (
+        <Loader />
+      ) : (
+        <div style={{ height: 400, width: "100%" }} className="text-center">
+          <h5>Earnings Trends for</h5>
+          <h3>past 15 days</h3>
+          <ResponsiveLine
+            data={earningsData}
+            margin={{ top: 50, right: 15, bottom: 75, left: 50 }}
+            xScale={{ type: "point" }}
+            colors={{ scheme: "category10" }}
+            yScale={{
+              type: "linear",
+              min: "auto",
+              max: "auto",
+              stacked: true,
+              reverse: false,
+            }}
+            yFormat=" >-.2f"
+            curve="cardinal"
+            lineWidth={1}
+            axisTop={null}
+            axisRight={null}
+            axisBottom={{
+              orient: "bottom",
+              tickSize: 5,
+              tickPadding: 5,
+              tickRotation: 0,
+              legend: "Dates",
+              legendOffset: 36,
+              legendPosition: "middle",
+              format: (value) => {
+                return Number(value) % 2 === 0 ? (value as string) : "";
+              },
+            }}
+            axisLeft={{
+              orient: "left",
+              tickSize: 5,
+              tickPadding: 5,
+              tickRotation: 0,
+              legend: "Earnings",
+              legendOffset: -40,
+              legendPosition: "middle",
+            }}
+            pointSize={2}
+            pointColor={{ theme: "background" }}
+            pointBorderWidth={2}
+            pointBorderColor={{ from: "serieColor" }}
+            pointLabelYOffset={-12}
+            useMesh={true}
+            legends={[
+              {
+                anchor: "bottom",
+                direction: "row",
+                justify: false,
+                translateX: 0,
+                translateY: 75,
+                itemsSpacing: 0,
+                itemDirection: "left-to-right",
+                itemWidth: 105,
+                itemHeight: 20,
+                itemOpacity: 0.75,
+                symbolSize: 18,
+                symbolShape: "circle",
+                symbolBorderColor: "rgba(0, 0, 0, .5)",
+                effects: [
+                  {
+                    on: "hover",
+                    style: {
+                      itemBackground: "rgba(0, 0, 0, .03)",
+                      itemOpacity: 1,
+                    },
+                  },
+                ],
+              },
+            ]}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default WagesTrends;

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,15 @@
+/**
+ * Added rules for react-spring to fix the bugs for @Nivo
+ * https://github.com/plouc/nivo/issues/1290
+ * 
+ */
+module.exports = {    
+    webpack: config => {
+      config.module.rules.push({
+        test: /react-spring/,
+        sideEffects: true,
+      })
+  
+      return config
+    },
+  }

--- a/next.config.js
+++ b/next.config.js
@@ -1,15 +1,15 @@
 /**
  * Added rules for react-spring to fix the bugs for @Nivo
  * https://github.com/plouc/nivo/issues/1290
- * 
+ *
  */
-module.exports = {    
-    webpack: config => {
-      config.module.rules.push({
-        test: /react-spring/,
-        sideEffects: true,
-      })
-  
-      return config
-    },
-  }
+module.exports = {
+  webpack: (config) => {
+    config.module.rules.push({
+      test: /react-spring/,
+      sideEffects: true,
+    });
+
+    return config;
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -623,6 +623,22 @@
         "recompose": "^0.30.0"
       }
     },
+    "@nivo/line": {
+      "version": "0.67.0",
+      "resolved": "https://registry.npmjs.org/@nivo/line/-/line-0.67.0.tgz",
+      "integrity": "sha512-+iZpvVekl6GXZl+GnqL5kvtIhNl05tkcCJ6ajheVmOuzaFV7J9xBk8E3bFqNtFDM+vt4b0ggujW8zrlrZvrwUg==",
+      "requires": {
+        "@nivo/annotations": "0.67.0",
+        "@nivo/axes": "0.67.0",
+        "@nivo/colors": "0.67.0",
+        "@nivo/legends": "0.67.0",
+        "@nivo/scales": "0.67.0",
+        "@nivo/tooltip": "0.67.0",
+        "@nivo/voronoi": "0.67.0",
+        "d3-shape": "^1.3.5",
+        "react-spring": "9.0.0-rc.3"
+      }
+    },
     "@nivo/pie": {
       "version": "0.67.0",
       "resolved": "https://registry.npmjs.org/@nivo/pie/-/pie-0.67.0.tgz",
@@ -666,6 +682,16 @@
       "integrity": "sha512-Z4h4Ks/fFd7Cl2uSG/trfSYLXaiQNyFX2wGJrE/UPzDSpf4XqaW8uEBaK3p46200WG2AgltG0fHrouGNyMJ+1g==",
       "requires": {
         "react-spring": "9.0.0-rc.3"
+      }
+    },
+    "@nivo/voronoi": {
+      "version": "0.67.0",
+      "resolved": "https://registry.npmjs.org/@nivo/voronoi/-/voronoi-0.67.0.tgz",
+      "integrity": "sha512-Z+e+fa92xWIhbpSRdQGJtei3bBHTbLnsmXtfje+Xz8LYpkyxp8R/iTs9cqzQ4KILp1Tv6EnQYWrFWNizN3fNGA==",
+      "requires": {
+        "d3-delaunay": "^5.1.1",
+        "d3-scale": "^3.0.0",
+        "recompose": "^0.30.0"
       }
     },
     "@nodelib/fs.scandir": {
@@ -2823,6 +2849,14 @@
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
       "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
     },
+    "d3-delaunay": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-5.3.0.tgz",
+      "integrity": "sha512-amALSrOllWVLaHTnDLHwMIiz0d1bBu9gZXd1FiLfXf8sHcX9jrcj81TVZOqD4UX7MgBZZ07c8GxzEgBpJqc74w==",
+      "requires": {
+        "delaunator": "4"
+      }
+    },
     "d3-format": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
@@ -3010,6 +3044,11 @@
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         }
       }
+    },
+    "delaunator": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
+      "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag=="
     },
     "delayed-stream": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -623,6 +623,18 @@
         "recompose": "^0.30.0"
       }
     },
+    "@nivo/pie": {
+      "version": "0.67.0",
+      "resolved": "https://registry.npmjs.org/@nivo/pie/-/pie-0.67.0.tgz",
+      "integrity": "sha512-TYxwvX5xCPQ+vUOFAPjhvwWw++/HXdRzCm08RHCAWtH5iNPwMoALPh2cSawqcVFwxNPnh0xv/nLTKkZIq2N2dw==",
+      "requires": {
+        "@nivo/colors": "0.67.0",
+        "@nivo/legends": "0.67.0",
+        "@nivo/tooltip": "0.67.0",
+        "d3-shape": "^1.3.5",
+        "lodash": "^4.17.11"
+      }
+    },
     "@nivo/scales": {
       "version": "0.67.0",
       "resolved": "https://registry.npmjs.org/@nivo/scales/-/scales-0.67.0.tgz",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@mobiscroll/react": "https://npm.mobiscroll.com/@mobiscroll/react-trial/-/react-trial-5.1.1.tgz",
     "@nivo/bar": "^0.67.0",
     "@nivo/core": "^0.67.0",
+    "@nivo/line": "^0.67.0",
     "@nivo/pie": "^0.67.0",
     "bcrypt": "^5.0.0",
     "bootstrap": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@mobiscroll/react": "https://npm.mobiscroll.com/@mobiscroll/react-trial/-/react-trial-5.1.1.tgz",
     "@nivo/bar": "^0.67.0",
     "@nivo/core": "^0.67.0",
+    "@nivo/pie": "^0.67.0",
     "bcrypt": "^5.0.0",
     "bootstrap": "^4.6.0",
     "classnames": "^2.2.6",

--- a/pages/future-analytics.tsx
+++ b/pages/future-analytics.tsx
@@ -10,19 +10,11 @@ import WagesTipsVisualizer from "components/analytics/trends-visualization/wages
 
 import stylesBackground from "styles/Home.module.css";
 import styles from "styles/analytics.module.css";
+import { getDateFromRequestQuery } from "utils/date-utils";
 
 const FutureAnalytics: React.FunctionComponent = () => {
   const router = useRouter();
-
-  let startDate = new Date();
-  if (router.query?.date) {
-    const { date } = router.query;
-    if (typeof date === "string") {
-      startDate = new Date(date);
-    } else {
-      startDate = new Date(date[0]);
-    }
-  }
+  const startDate = getDateFromRequestQuery(router.query);
 
   return (
     <PrivateLayout backgroundStyle={stylesBackground.dashboard}>

--- a/pages/home.tsx
+++ b/pages/home.tsx
@@ -6,6 +6,8 @@ import PrivateLayout from "components/layouts/private-layout";
 import styles from "styles/Home.module.css";
 import WorkSchedule from "components/work-schedule/schedule-display";
 import UserDetails from "components/user-details/";
+import WagesDistribution from "components/visualizations/monthly-summary/wagesDistribution";
+import WagesTrends from "components/visualizations/monthly-summary/wagesTrends";
 
 interface HomeProps {
   session: {
@@ -60,6 +62,14 @@ export function Home(props: HomeProps): JSX.Element {
                   endTime="21:00"
                 />
               </div>
+            </Col>
+          </Row>
+          <Row>
+            <Col xs={12} xl={5} className="my-3">
+              <WagesDistribution />
+            </Col>
+            <Col xs={12} xl={7} className="my-3">
+              <WagesTrends />
             </Col>
           </Row>
         </Container>

--- a/pages/past-analytics.tsx
+++ b/pages/past-analytics.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/router";
 
 import { ShiftTrendsProvider } from "src/providers/ShiftTrendsContext";
 import { getPastTrends } from "src/actions/trends";
+import { getDateFromRequestQuery } from "utils/date-utils";
 import WeekCalendar from "components/analytics/calendar";
 import PrivateLayout from "components/layouts/private-layout";
 import WagesTipsVisualizer from "components/analytics/trends-visualization/wagesTipsVisualizer";
@@ -13,16 +14,7 @@ import stylesBackground from "styles/Home.module.css";
 
 const PastAnalytics: React.FunctionComponent = () => {
   const router = useRouter();
-
-  let startDate = new Date();
-  if (router.query?.date) {
-    const { date } = router.query;
-    if (typeof date === "string") {
-      startDate = new Date(date);
-    } else {
-      startDate = new Date(date[0]);
-    }
-  }
+  const startDate = getDateFromRequestQuery(router.query);
 
   return (
     <PrivateLayout backgroundStyle={stylesBackground.dashboard}>

--- a/src/actions/visualizations.ts
+++ b/src/actions/visualizations.ts
@@ -131,11 +131,11 @@ export const getEarningsTrendsData = async (days: number) => {
         };
       });
 
-      const result = [
-        { id: "Wages", data: [] },
-        { id: "Cash Tips", data: [] },
-        { id: "Credit Card Tips", data: [] },
-      ];
+      const trends = {
+        wages: [],
+        "Cash Tips": [],
+        "Credit Card Tips": [],
+      };
 
       const today = new Date();
       let currentDate = addDays(today, -days);
@@ -144,17 +144,17 @@ export const getEarningsTrendsData = async (days: number) => {
         const day = format(currentDate, "yyyy-MM-dd");
         const index = format(currentDate, "d");
 
-        result[0].data.push({
+        trends.wages.push({
           x: index,
           y: dataByDays[day]?.wages?.toFixed(2) || 0,
         });
 
-        result[1].data.push({
+        trends["Cash Tips"].push({
           x: index,
           y: dataByDays[day]?.cashTips?.toFixed(2) || 0,
         });
 
-        result[2].data.push({
+        trends["Credit Card Tips"].push({
           x: index,
           y: dataByDays[day]?.ccTips?.toFixed(2) || 0,
         });
@@ -162,6 +162,8 @@ export const getEarningsTrendsData = async (days: number) => {
         currentDate = addDays(currentDate, 1);
       }
 
-      return result;
+      return Object.keys(trends).map((x) => {
+        return { id: x, data: trends[x] };
+      });
     });
 };

--- a/src/actions/visualizations.ts
+++ b/src/actions/visualizations.ts
@@ -1,0 +1,73 @@
+import { addDays, differenceInMinutes, format } from "date-fns";
+import { parseISODate } from "utils/date-utils";
+
+export const getEarningsDistributionData = async (days: number) => {
+  const endDate = new Date();
+  const startDate = addDays(endDate, -days);
+
+  const baseUrl = "api/summary/summary-data";
+  const queries = `start_date=${encodeURIComponent(
+    format(startDate, "yyyy-MM-dd")
+  )}&end_date=${encodeURIComponent(format(endDate, "yyyy-MM-dd"))}`;
+
+  const earnings = {
+    wages: 0,
+    ccTips: 0,
+    cashTips: 0,
+  };
+
+  return await fetch(`${baseUrl}?${queries}`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+  })
+    .then((response) => response.json())
+    .then((data) => {
+      data.shiftDetail?.hourlyShiftDetails.forEach((shiftDetail) => {
+        const {
+          start_time,
+          end_time,
+          hourly_wage,
+          credit_card_tips,
+          cash_tips,
+        } = shiftDetail;
+
+        const parsedStartTime = parseISODate(start_time);
+        const parsedEndTime = parseISODate(end_time);
+        const shiftInterval =
+          differenceInMinutes(parsedEndTime, parsedStartTime) / 60;
+
+        earnings.wages += shiftInterval * hourly_wage;
+        earnings.cashTips += cash_tips || 0;
+        earnings.ccTips += credit_card_tips || 0;
+      });
+
+      data.shiftDetail?.nonHourlyShiftDetails.forEach((shiftDetail) => {
+        const { total_base_earning, credit_card_tips, cash_tips } = shiftDetail;
+
+        earnings.wages += total_base_earning;
+        earnings.cashTips += cash_tips || 0;
+        earnings.ccTips += credit_card_tips || 0;
+      });
+
+      return [
+        {
+          id: "Wages",
+          label: "Wages",
+          value: earnings.wages.toFixed(2),
+        },
+        {
+          id: "Cash Tips",
+          label: "Cash Tips",
+          value: earnings.cashTips.toFixed(2),
+        },
+        {
+          id: "Credit Card Tips",
+          label: "Credit Card Tips",
+          value: earnings.ccTips.toFixed(2),
+        },
+      ];
+    });
+};

--- a/src/actions/visualizations.ts
+++ b/src/actions/visualizations.ts
@@ -1,7 +1,7 @@
 import { addDays, differenceInMinutes, format } from "date-fns";
-import { parseISODate } from "utils/date-utils";
+import { getFormattedShiftDate, parseISODate } from "utils/date-utils";
 
-export const getEarningsDistributionData = async (days: number) => {
+const getRequestURL = (days: number) => {
   const endDate = new Date();
   const startDate = addDays(endDate, -days);
 
@@ -10,13 +10,18 @@ export const getEarningsDistributionData = async (days: number) => {
     format(startDate, "yyyy-MM-dd")
   )}&end_date=${encodeURIComponent(format(endDate, "yyyy-MM-dd"))}`;
 
+  return `${baseUrl}?${queries}`;
+};
+
+export const getEarningsDistributionData = async (days: number) => {
   const earnings = {
     wages: 0,
     ccTips: 0,
     cashTips: 0,
   };
 
-  return await fetch(`${baseUrl}?${queries}`, {
+  const url = getRequestURL(days);
+  return await fetch(url, {
     method: "GET",
     headers: {
       "Content-Type": "application/json",
@@ -69,5 +74,94 @@ export const getEarningsDistributionData = async (days: number) => {
           value: earnings.ccTips.toFixed(2),
         },
       ];
+    });
+};
+
+export const getEarningsTrendsData = async (days: number) => {
+  const url = getRequestURL(days);
+
+  const dataByDays = {};
+
+  return await fetch(url, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+  })
+    .then((response) => response.json())
+    .then((data) => {
+      data.shiftDetail?.hourlyShiftDetails.forEach((shiftDetail) => {
+        const {
+          shift_date,
+          start_time,
+          end_time,
+          hourly_wage,
+          credit_card_tips,
+          cash_tips,
+        } = shiftDetail;
+
+        const formattedShiftDate = getFormattedShiftDate(shift_date);
+
+        const parsedStartTime = parseISODate(start_time);
+        const parsedEndTime = parseISODate(end_time);
+        const shiftInterval =
+          differenceInMinutes(parsedEndTime, parsedStartTime) / 60;
+
+        dataByDays[formattedShiftDate] = {
+          wages: shiftInterval * hourly_wage,
+          ccTips: credit_card_tips,
+          cashTips: cash_tips,
+        };
+      });
+
+      data.shiftDetail?.nonHourlyShiftDetails.forEach((shiftDetail) => {
+        const {
+          shift_date,
+          total_base_earning,
+          credit_card_tips,
+          cash_tips,
+        } = shiftDetail;
+
+        const formattedShiftDate = getFormattedShiftDate(shift_date);
+        dataByDays[formattedShiftDate] = {
+          wages: total_base_earning,
+          ccTips: credit_card_tips,
+          cashTips: cash_tips,
+        };
+      });
+
+      const result = [
+        { id: "Wages", data: [] },
+        { id: "Cash Tips", data: [] },
+        { id: "Credit Card Tips", data: [] },
+      ];
+
+      const today = new Date();
+      let currentDate = addDays(today, -days);
+
+      while (currentDate <= today) {
+        const day = format(currentDate, "yyyy-MM-dd");
+        const index = format(currentDate, "d");
+
+        result[0].data.push({
+          x: index,
+          y: dataByDays[day]?.wages?.toFixed(2) || 0,
+        });
+
+        result[1].data.push({
+          x: index,
+          y: dataByDays[day]?.cashTips?.toFixed(2) || 0,
+        });
+
+        result[2].data.push({
+          x: index,
+          y: dataByDays[day]?.ccTips?.toFixed(2) || 0,
+        });
+
+        currentDate = addDays(currentDate, 1);
+      }
+
+      return result;
     });
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,6 @@
     "jsx": "preserve",
     "baseUrl": "."
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "next.config.js"],
   "exclude": ["node_modules"]
 }

--- a/utils/date-utils.ts
+++ b/utils/date-utils.ts
@@ -1,4 +1,4 @@
-import { addMinutes, format, parseISO } from "date-fns";
+import { addMinutes, format, parse, parseISO } from "date-fns";
 
 export function parseISODate(isoDate: string): Date {
   const parsedDate = parseISO(isoDate);
@@ -36,4 +36,24 @@ export function parseTimeString(time: string): string {
   const formattedMinutes = minutes < 10 ? `0${minutes}` : String(minutes);
 
   return `${hour}:${formattedMinutes} ${timeOfDay}`;
+}
+
+export function getDateFromRequestQuery(query) {
+  let currentDate = new Date();
+  if (query?.date) {
+    const { date } = query;
+    let rawStartDate = "";
+    if (typeof date === "string") {
+      rawStartDate = date;
+    } else {
+      rawStartDate = date[0];
+    }
+    try {
+      currentDate = parse(rawStartDate, "yyyy-MM-dd", currentDate);
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  return currentDate;
 }


### PR DESCRIPTION
# Data Visualization
- Added the following reusable data visualization components
  - Pie Chart to show earning distribution for the past 30 days
  - Line Chart to show earning trends for the past 15 days

![image](https://user-images.githubusercontent.com/43834826/115120865-bae17c00-9f7d-11eb-9288-bf24b99d886b.png)

# Bug Fix
We noticed that in preview and production, the charts were not being generated completely. For instance, for Bar Graph on Past Trends, there were missing x-axis and y-axis values.
![image](https://user-images.githubusercontent.com/43834826/115120899-e19fb280-9f7d-11eb-8931-97e44b7a5ed6.png)

Upon investigation, this was due to an error with a dependency of `Nivo`for `react-spring` package.
![image](https://user-images.githubusercontent.com/43834826/115120954-3a6f4b00-9f7e-11eb-8d34-2c137f602c3a.png)
This was a well-know issue with other users as well (https://github.com/plouc/nivo/issues/1290).

Although `Nivo` is planning to address this issue on next release, a quick fix was found [here](https://github.com/plouc/nivo/issues/1290#issuecomment-752280413).